### PR TITLE
Support a default action for marketplace

### DIFF
--- a/.github/workflows/test-composed-flow.yml
+++ b/.github/workflows/test-composed-flow.yml
@@ -17,6 +17,13 @@ jobs:
         with:
           project_dir: ./.github/workflows/test-project
       - name: HubSpot Project Upload Action
+        id: upload-project-step
         uses: ./project-upload
         with:
           project_dir: ./.github/workflows/test-project
+      - name: HubSpot Project Deploy Action
+        if: ${{ steps.upload-project-step.outputs.build_id != '' }}
+        uses: ./project-deploy
+        with:
+          project_dir: ./.github/workflows/test-project
+          deploy_latest_build: true

--- a/.github/workflows/test-default-action.yml
+++ b/.github/workflows/test-default-action.yml
@@ -1,0 +1,18 @@
+on: [push, workflow_dispatch]
+
+env:
+  DEFAULT_PERSONAL_ACCESS_KEY: ${{ secrets.HUBSPOT_PERSONAL_ACCESS_KEY }}
+  DEFAULT_ACCOUNT_ID: ${{ secrets.HUBSPOT_ACCOUNT_ID }}
+  DEFAULT_PROFILE: "prod"
+  DEFAULT_CLI_VERSION: "7.6.0-beta.3"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+      - name: HubSpot Default Action
+        uses: ./action.yml
+        with:
+          project_dir: ./.github/workflows/test-project

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use these composable workflow actions to upload, deploy, and validate your HubSp
 
 Don't know where to start? Follow the usage guide below to set up a basic flow to upload your project into your HubSpot account.
 
-## Basic usage - Uploading your project
+## Basic usage - Uploading your project using our default action
 
 In your GitHub repo, create two new [secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for:
 
@@ -43,8 +43,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3
-      - name: HubSpot Project Upload Action
-        uses: HubSpot/hubspot-project-actions/project-upload@v1.0.0
+      - name: HubSpot Project Default Action
+        uses: HubSpot/hubspot-project-actions@v1.0.0
 ```
 
 3. Commit and merge your changes
@@ -69,6 +69,7 @@ HubSpot/hubspot-project-actions/[action-name]@v[version]
 
 For example:
 
+- `HubSpot/hubspot-project-actions@v1.0.0`
 - `HubSpot/hubspot-project-actions/project-upload@v1.0.0`
 - `HubSpot/hubspot-project-actions/project-deploy@v1.2.3`
 - `HubSpot/hubspot-project-actions/project-validate@v2.0.0`

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,53 @@
+name: "Default Project Action"
+description: "Validate, upload, and deploy a HubSpot project"
+inputs:
+  project_dir:
+    description: "The path to the directory where your hsproject.json file is located"
+    required: true
+    default: ./
+    type: string
+  personal_access_key:
+    description: "[SECRET] Personal Access Key generated in HubSpot that grants access to the CLI. If not provided, will use DEFAULT_PERSONAL_ACCESS_KEY from environment."
+    required: false
+    type: string
+  account_id:
+    description: "HubSpot account ID associated with the personal-access-key. If not provided, will use DEFAULT_ACCOUNT_ID from environment."
+    required: false
+    type: number
+  cli_version:
+    description: "Version of the HubSpot CLI to install. If not provided, will use DEFAULT_CLI_VERSION from environment. If neither are found, defaults to `latest`."
+    required: false
+    type: string
+  profile:
+    description: "Profile to use for the HubSpot CLI. If not provided, will use DEFAULT_PROFILE from environment."
+    required: false
+    type: string
+outputs:
+  build_id:
+    description: "The build ID of the created HubSpot project build"
+  deploy_id:
+    description: "The deploy ID if auto-deploy is enabled"
+runs:
+  using: "composite"
+  outputs:
+    build_id: ${{ steps.upload-project-step.outputs.build_id }}
+    deploy_id: ${{ steps.upload-project-step.outputs.deploy_id }}
+  env:
+    HUBSPOT_PERSONAL_ACCESS_KEY: ${{ inputs.personal_access_key || env.DEFAULT_PERSONAL_ACCESS_KEY }}
+    HUBSPOT_ACCOUNT_ID: ${{ inputs.account_id || env.DEFAULT_ACCOUNT_ID }}
+    HUBSPOT_PROFILE: ${{ inputs.profile || env.DEFAULT_PROFILE }}
+  steps:
+    - name: Install HubSpot CLI
+      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v0.1.0
+      with:
+        cli_version: ${{ inputs.cli_version }}
+    - name: Validate HubSpot Project
+      uses: HubSpot/hubspot-project-actions/project-validate@v0.1.0
+      with:
+        project_dir: ${{ inputs.project_dir }}
+    - name: Upload HubSpot Project
+      id: upload-project-step
+      uses: HubSpot/hubspot-project-actions/project-upload@v0.1.0
+      with:
+        project_dir: ${{ inputs.project_dir }}
+

--- a/project-deploy/action.yml
+++ b/project-deploy/action.yml
@@ -36,7 +36,7 @@ runs:
   using: "composite"
   steps:
     - name: Install HubSpot CLI
-      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v0.0.1
+      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v0.1.0
       with:
         cli_version: ${{ inputs.cli_version }}
     - name: Deploy a HubSpot project build

--- a/project-upload/action.yml
+++ b/project-upload/action.yml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Install HubSpot CLI
-      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v0.0.1
+      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v0.1.0
       with:
         cli_version: ${{ inputs.cli_version }}
     - name: Upload source code to HubSpot Project

--- a/project-validate/action.yml
+++ b/project-validate/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Install HubSpot CLI
-      uses: Hubspot/hubspot-project-actions/install-hubspot-cli@v0.0.1
+      uses: Hubspot/hubspot-project-actions/install-hubspot-cli@v0.1.0
       with:
         cli_version: ${{ inputs.cli_version }}
     - name: Validate HubSpot project


### PR DESCRIPTION
This [github marketplace guide](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/publish-in-github-marketplace) lists the requirements of publishing. One of them is that you can only publish a single action to the marketplace. You need a root-level `action.yml` file, and that's the action that'll be posted.

This sets our actions repo up to have a default action. It's a simple one for now that validates and uploads the project, but we can expand on the behavior down the road.