### PR TITLE
fix: prevent command substitution from commit messages in project-upload

### DIFF
--- a/.github/workflows/test-message-escaping.yml
+++ b/.github/workflows/test-message-escaping.yml
@@ -1,0 +1,73 @@
+name: Test Message Escaping
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test-message-escaping:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test that shell metacharacters in commit messages are preserved
+        shell: bash
+        run: |
+          . ./scripts/action-utils.sh
+
+          # Mock hs CLI: captures the --message value to a file and returns valid JSON
+          hs() {
+            while [[ $# -gt 0 ]]; do
+              case "$1" in
+                --message) echo "$2" > /tmp/captured_message; shift 2 ;;
+                *) shift ;;
+              esac
+            done
+            echo '{"buildId":"test-123","deployId":"test-456"}'
+          }
+          export -f hs
+
+          test_message() {
+            local test_name="$1"
+            local input="$2"
+            local expected="$3"
+
+            HEAD_COMMIT_MESSAGE="$input"
+            UPLOAD_MESSAGE="$(printf '%s' "$HEAD_COMMIT_MESSAGE" | head -n 1) (abc1234)"
+
+            run_hs_command \
+              "hs project upload --force-create --use-env --json --message \"\$UPLOAD_MESSAGE\"" \
+              "true"
+
+            local captured
+            captured=$(cat /tmp/captured_message)
+
+            if [[ "$captured" == *"$expected"* ]]; then
+              echo "PASS: $test_name"
+            else
+              echo "FAIL: $test_name"
+              echo "  Expected to contain: $expected"
+              echo "  Got: $captured"
+              exit 1
+            fi
+          }
+
+          test_message \
+            "backticks are preserved" \
+            'Wire repo to `some-workflow.yml@v1` per pattern in `other-repo`' \
+            '`some-workflow.yml@v1`'
+
+          test_message \
+            "dollar-paren command substitution is not executed" \
+            'Test $(echo pwned) in message' \
+            '$(echo pwned)'
+
+          test_message \
+            "double quotes are preserved" \
+            'Test with "double quotes" inside' \
+            '"double quotes"'
+
+          test_message \
+            "multiline message is truncated to first line" \
+            $'First line\nSecond line\nThird line' \
+            'First line'
+
+          echo ""
+          echo "All message escaping tests passed"

--- a/project-upload/action.yml
+++ b/project-upload/action.yml
@@ -62,6 +62,8 @@ runs:
           PROFILE_ARG="--profile $HUBSPOT_PROFILE"
         fi
 
+        # Build the upload message from the env var (not via ${{ }} template interpolation) so that
+        # shell metacharacters like backticks in the commit message are never executed by bash.
         UPLOAD_MESSAGE="$(printf '%s' "$HEAD_COMMIT_MESSAGE" | head -n 1) (${GITHUB_SHA:0:7})"
 
         # Run upload command

--- a/project-upload/action.yml
+++ b/project-upload/action.yml
@@ -45,6 +45,7 @@ runs:
         HUBSPOT_ACCOUNT_ID: ${{ inputs.account_id || env.DEFAULT_ACCOUNT_ID }}
         HUBSPOT_PROFILE: ${{ inputs.profile || env.DEFAULT_PROFILE }}
         DEBUG_MODE: ${{ inputs.debug || env.DEFAULT_DEBUG}}
+        HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message || 'Uploaded via HubSpot GitHub Action' }}
       run: |
         # Source shared utilities
         . "$GITHUB_ACTION_PATH/../scripts/action-utils.sh"
@@ -61,9 +62,11 @@ runs:
           PROFILE_ARG="--profile $HUBSPOT_PROFILE"
         fi
 
+        UPLOAD_MESSAGE="$(printf '%s' "$HEAD_COMMIT_MESSAGE" | head -n 1) (${GITHUB_SHA:0:7})"
+
         # Run upload command
         run_hs_command \
-          "hs project upload --force-create --use-env --json --message '${{ github.event.head_commit.message || 'Uploaded via HubSpot GitHub Action' }} (${GITHUB_SHA:0:7})' $PROFILE_ARG" \
+          "hs project upload --force-create --use-env --json --message \"\$UPLOAD_MESSAGE\" $PROFILE_ARG" \
           "true"
 
         # Parse and set outputs


### PR DESCRIPTION
## Summary

Commit messages containing backticks or `$(...)` were being interpolated directly into a bash command string via `${{ github.event.head_commit.message }}`, causing bash to execute them as commands. This broke deploys for any commit message with backtick-quoted text — a common pattern in merge commit bodies.

The fix follows [GitHub's recommended mitigation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections): pass the commit message through an environment variable instead of interpolating it into the shell script source.

- Moves the commit message to `HEAD_COMMIT_MESSAGE` in the step's `env:` block
- Builds `UPLOAD_MESSAGE` via parameter expansion (safe from command substitution)
- Passes it to `run_hs_command` with an escaped `$` so the `eval` inside expands it safely
- Truncates to the first line to avoid multi-line messages breaking the CLI argument
- Adds a test workflow that mocks `hs` and verifies backticks, `$(...)`, double quotes, and multi-line messages all pass through correctly

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)