### PR TITLE
fix: Escape upload message to handle quotes in commit messages + fix bug with expression in comment

### DIFF
--- a/.github/workflows/test-message-escaping.yml
+++ b/.github/workflows/test-message-escaping.yml
@@ -32,8 +32,9 @@ jobs:
             HEAD_COMMIT_MESSAGE="$input"
             UPLOAD_MESSAGE="$(printf '%s' "$HEAD_COMMIT_MESSAGE" | head -n 1) (abc1234)"
 
+            SAFE_MSG=$(printf '%q' "$UPLOAD_MESSAGE")
             run_hs_command \
-              "hs project upload --force-create --use-env --json --message $(printf '%q' "$UPLOAD_MESSAGE")" \
+              "hs project upload --force-create --use-env --json --message $SAFE_MSG" \
               "true"
 
             local captured

--- a/.github/workflows/test-message-escaping.yml
+++ b/.github/workflows/test-message-escaping.yml
@@ -33,7 +33,7 @@ jobs:
             UPLOAD_MESSAGE="$(printf '%s' "$HEAD_COMMIT_MESSAGE" | head -n 1) (abc1234)"
 
             run_hs_command \
-              "hs project upload --force-create --use-env --json --message \"\$UPLOAD_MESSAGE\"" \
+              "hs project upload --force-create --use-env --json --message $(printf '%q' "$UPLOAD_MESSAGE")" \
               "true"
 
             local captured
@@ -58,6 +58,11 @@ jobs:
             "dollar-paren command substitution is not executed" \
             'Test $(echo pwned) in message' \
             '$(echo pwned)'
+
+          test_message \
+            "single quotes are preserved" \
+            "Test with 'single quotes' inside" \
+            "'single quotes'"
 
           test_message \
             "double quotes are preserved" \

--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,11 @@ runs:
   using: "composite"
   steps:
     - name: Install HubSpot CLI
-      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.0
+      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.1
       with:
         cli_version: ${{ inputs.cli_version }}
     - name: Validate HubSpot Project
-      uses: HubSpot/hubspot-project-actions/project-validate@v1.1.0
+      uses: HubSpot/hubspot-project-actions/project-validate@v1.1.1
       with:
         project_dir: ${{ inputs.project_dir }}
         personal_access_key: ${{ inputs.personal_access_key }}
@@ -50,7 +50,7 @@ runs:
         profile: ${{ inputs.profile }}
     - name: Upload HubSpot Project
       id: upload-project-step
-      uses: HubSpot/hubspot-project-actions/project-upload@v1.1.0
+      uses: HubSpot/hubspot-project-actions/project-upload@v1.1.1
       with:
         project_dir: ${{ inputs.project_dir }}
         personal_access_key: ${{ inputs.personal_access_key }}

--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,11 @@ runs:
   using: "composite"
   steps:
     - name: Install HubSpot CLI
-      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.1
+      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.0
       with:
         cli_version: ${{ inputs.cli_version }}
     - name: Validate HubSpot Project
-      uses: HubSpot/hubspot-project-actions/project-validate@v1.1.1
+      uses: HubSpot/hubspot-project-actions/project-validate@v1.1.0
       with:
         project_dir: ${{ inputs.project_dir }}
         personal_access_key: ${{ inputs.personal_access_key }}
@@ -50,7 +50,7 @@ runs:
         profile: ${{ inputs.profile }}
     - name: Upload HubSpot Project
       id: upload-project-step
-      uses: HubSpot/hubspot-project-actions/project-upload@v1.1.1
+      uses: HubSpot/hubspot-project-actions/project-upload@v1.1.0
       with:
         project_dir: ${{ inputs.project_dir }}
         personal_access_key: ${{ inputs.personal_access_key }}

--- a/project-upload/action.yml
+++ b/project-upload/action.yml
@@ -45,7 +45,6 @@ runs:
         HUBSPOT_ACCOUNT_ID: ${{ inputs.account_id || env.DEFAULT_ACCOUNT_ID }}
         HUBSPOT_PROFILE: ${{ inputs.profile || env.DEFAULT_PROFILE }}
         DEBUG_MODE: ${{ inputs.debug || env.DEFAULT_DEBUG}}
-        HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message || 'Uploaded via HubSpot GitHub Action' }}
       run: |
         # Source shared utilities
         . "$GITHUB_ACTION_PATH/../scripts/action-utils.sh"
@@ -62,9 +61,11 @@ runs:
           PROFILE_ARG="--profile $HUBSPOT_PROFILE"
         fi
 
-        # Build the upload message from the env var (not via ${{ }} template interpolation) so that
-        # shell metacharacters like backticks in the commit message are never executed by bash.
-        UPLOAD_MESSAGE="$(printf '%s' "$HEAD_COMMIT_MESSAGE" | head -n 1) (${GITHUB_SHA:0:7})"
+        # Read the commit message from the event payload at runtime to avoid template
+        # interpolation, so shell metacharacters in the message are never executed.
+        # GITHUB_EVENT_PATH is always set by the runner and points to the full event JSON.
+        HEAD_COMMIT_MESSAGE=$(jq -r '.head_commit.message // ""' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
+        UPLOAD_MESSAGE="$(printf '%s' "${HEAD_COMMIT_MESSAGE:-Uploaded via HubSpot GitHub Action}" | head -n 1) (${GITHUB_SHA:0:7})"
 
         # printf '%q' shell-escapes UPLOAD_MESSAGE so that eval in run_hs_command
         # treats quotes and other special characters in the value as literals.

--- a/project-upload/action.yml
+++ b/project-upload/action.yml
@@ -67,8 +67,10 @@ runs:
         UPLOAD_MESSAGE="$(printf '%s' "$HEAD_COMMIT_MESSAGE" | head -n 1) (${GITHUB_SHA:0:7})"
 
         # Run upload command
+        # printf '%q' shell-escapes UPLOAD_MESSAGE so that eval in run_hs_command
+        # treats quotes and other special characters in the value as literals.
         run_hs_command \
-          "hs project upload --force-create --use-env --json --message \"\$UPLOAD_MESSAGE\" $PROFILE_ARG" \
+          "hs project upload --force-create --use-env --json --message $(printf '%q' "$UPLOAD_MESSAGE") $PROFILE_ARG" \
           "true"
 
         # Parse and set outputs

--- a/project-upload/action.yml
+++ b/project-upload/action.yml
@@ -66,11 +66,13 @@ runs:
         # shell metacharacters like backticks in the commit message are never executed by bash.
         UPLOAD_MESSAGE="$(printf '%s' "$HEAD_COMMIT_MESSAGE" | head -n 1) (${GITHUB_SHA:0:7})"
 
-        # Run upload command
         # printf '%q' shell-escapes UPLOAD_MESSAGE so that eval in run_hs_command
         # treats quotes and other special characters in the value as literals.
+        SAFE_MSG=$(printf '%q' "$UPLOAD_MESSAGE")
+
+        # Run upload command
         run_hs_command \
-          "hs project upload --force-create --use-env --json --message $(printf '%q' "$UPLOAD_MESSAGE") $PROFILE_ARG" \
+          "hs project upload --force-create --use-env --json --message $SAFE_MSG $PROFILE_ARG" \
           "true"
 
         # Parse and set outputs


### PR DESCRIPTION
## Summary

This fixes a bug where commit messages containing single or double quotes were breaking the upload step. The message was wrapped in quotes that could be broken by quote characters in the message, causing \`eval\` inside \`run_hs_command\` to see malformed shell syntax.

Additionally, the last PR (#53) introduced a bug where an  empty \`${{ }}\` expression in a comment was causing "An expression was expected" validation errors on every run. This is because GitHub Actions evaluates \`${{ }}\` expressions before bash runs. See: [orgs/community/discussions/26621](https://github.com/orgs/community/discussions/26621).

Also adds single and double quote test cases to the message escaping test workflow.

Closes #40

## References
- [GitHub Actions security hardening — script injection](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)
- [Escaping \`\${{ }}\` in workflows — community discussion](https://github.com/orgs/community/discussions/26621)

🤖 Generated with [Claude Code](https://claude.com/claude-code)