### PR TITLE
Update Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/scheduled-composed-flow.yml
+++ b/.github/workflows/scheduled-composed-flow.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: HubSpot Project Validation Action
         uses: ./project-validate
         with:

--- a/.github/workflows/scheduled-default-action.yml
+++ b/.github/workflows/scheduled-default-action.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: HubSpot Default Action
         uses: ./
         with:

--- a/.github/workflows/test-composed-flow.yml
+++ b/.github/workflows/test-composed-flow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: HubSpot Project Validation Action
         uses: ./project-validate
         with:

--- a/.github/workflows/test-default-action.yml
+++ b/.github/workflows/test-default-action.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: HubSpot Default Action
         uses: ./
         with:

--- a/.github/workflows/test-message-escaping.yml
+++ b/.github/workflows/test-message-escaping.yml
@@ -6,7 +6,7 @@ jobs:
   test-message-escaping:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Test that shell metacharacters in commit messages are preserved
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: HubSpot Project Action
-        uses: HubSpot/hubspot-project-actions@v1.1.0
+        uses: HubSpot/hubspot-project-actions@v1.1.2
 ```
 
 3. Commit and merge your changes
@@ -86,9 +86,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Upload to QA
-        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.0
+        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.2
         with:
           profile: "qa"
           account_id: ${{ secrets.HUBSPOT_QA_ACCOUNT_ID }}
@@ -132,7 +132,7 @@ See the [project-upload docs](./project-upload/README.md) for detailed specs.
 **Example usage:**
 
 ```yaml
-- uses: HubSpot/hubspot-project-actions/project-upload@v1.1.0
+- uses: HubSpot/hubspot-project-actions/project-upload@v1.1.2
   with:
     project_dir: "./my-project" # optional
 ```
@@ -146,7 +146,7 @@ See the [project-deploy docs](./project-deploy/README.md) for detailed specs.
 **Example usage:**
 
 ```yaml
-- uses: HubSpot/hubspot-project-actions/project-deploy@v1.1.0
+- uses: HubSpot/hubspot-project-actions/project-deploy@v1.1.2
   with:
     build_id: ${{ steps.upload-action-step.outputs.build_id }}
     project_dir: "./my-project" # optional
@@ -161,7 +161,7 @@ See the [project-validate docs](./project-validate/README.md) for detailed specs
 **Example usage:**
 
 ```yaml
-- uses: HubSpot/hubspot-project-actions/project-validate@v1.1.0
+- uses: HubSpot/hubspot-project-actions/project-validate@v1.1.2
   with:
     project_dir: "./my-project" # optional
 ```
@@ -175,7 +175,7 @@ See the [install-hubspot-cli docs](./install-hubspot-cli/README.md) for detailed
 **Example usage:**
 
 ```yaml
-- uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.0
+- uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.2
   with:
     cli_version: "8.0.0"
 ```

--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,11 @@ runs:
   using: "composite"
   steps:
     - name: Install HubSpot CLI
-      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.0
+      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.2
       with:
         cli_version: ${{ inputs.cli_version }}
     - name: Validate HubSpot Project
-      uses: HubSpot/hubspot-project-actions/project-validate@v1.1.0
+      uses: HubSpot/hubspot-project-actions/project-validate@v1.1.2
       with:
         project_dir: ${{ inputs.project_dir }}
         personal_access_key: ${{ inputs.personal_access_key }}
@@ -50,11 +50,10 @@ runs:
         profile: ${{ inputs.profile }}
     - name: Upload HubSpot Project
       id: upload-project-step
-      uses: HubSpot/hubspot-project-actions/project-upload@v1.1.0
+      uses: HubSpot/hubspot-project-actions/project-upload@v1.1.2
       with:
         project_dir: ${{ inputs.project_dir }}
         personal_access_key: ${{ inputs.personal_access_key }}
         account_id: ${{ inputs.account_id }}
         cli_version: ${{ inputs.cli_version }}
         profile: ${{ inputs.profile }}
-

--- a/install-hubspot-cli/README.md
+++ b/install-hubspot-cli/README.md
@@ -29,9 +29,9 @@ jobs:
       test_account_id: ${{ steps.test-account-create-step.outputs.account_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install HubSpot CLI Action
-        uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.0
+        uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.2
         with:
           cli_version: "8.0.0"
 ```

--- a/project-deploy/README.md
+++ b/project-deploy/README.md
@@ -35,14 +35,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: HubSpot Project Upload
         id: upload-step
-        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.0
+        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.2
         with:
           project_dir: "./my-project" # optional
       - name: HubSpot Project Deploy
-        uses: HubSpot/hubspot-project-actions/project-deploy@v1.1.0
+        uses: HubSpot/hubspot-project-actions/project-deploy@v1.1.2
         with:
           build_id: ${{ steps.upload-step.outputs.build_id }}
           project_dir: "./my-project" # optional
@@ -63,17 +63,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Upload to Production
         id: upload-step
-        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.0
+        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.2
         with:
           profile: "prod"
           account_id: ${{ secrets.HUBSPOT_PROD_ACCOUNT_ID }}
           personal_access_key: ${{ secrets.HUBSPOT_PROD_PERSONAL_ACCESS_KEY }}
           project_dir: "./my-project"
       - name: Deploy to Production
-        uses: HubSpot/hubspot-project-actions/project-deploy@v1.1.0
+        uses: HubSpot/hubspot-project-actions/project-deploy@v1.1.2
         with:
           profile: "prod"
           account_id: ${{ secrets.HUBSPOT_PROD_ACCOUNT_ID }}

--- a/project-deploy/action.yml
+++ b/project-deploy/action.yml
@@ -40,7 +40,7 @@ runs:
   using: "composite"
   steps:
     - name: Install HubSpot CLI
-      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.0
+      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.2
       with:
         cli_version: ${{ inputs.cli_version }}
     - name: Deploy a HubSpot project build

--- a/project-upload/README.md
+++ b/project-upload/README.md
@@ -35,9 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: HubSpot Project Upload
-        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.0
+        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.2
         with:
           project_dir: "./my-project" # optional
 ```
@@ -57,9 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Upload to QA Environment
-        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.0
+        uses: HubSpot/hubspot-project-actions/project-upload@v1.1.2
         with:
           profile: "qa"
           account_id: ${{ secrets.HUBSPOT_QA_ACCOUNT_ID }}

--- a/project-upload/action.yml
+++ b/project-upload/action.yml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
   steps:
     - name: Install HubSpot CLI
-      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.0
+      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.2
       with:
         cli_version: ${{ inputs.cli_version }}
     - name: Upload source code to HubSpot Project

--- a/project-validate/README.md
+++ b/project-validate/README.md
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: HubSpot Project Validation
-        uses: HubSpot/hubspot-project-actions/project-validate@v1.1.0
+        uses: HubSpot/hubspot-project-actions/project-validate@v1.1.2
         with:
           project_dir: "./my-project" # optional
 ```
@@ -50,9 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Validate Staging Configuration
-        uses: HubSpot/hubspot-project-actions/project-validate@v1.1.0
+        uses: HubSpot/hubspot-project-actions/project-validate@v1.1.2
         with:
           profile: "staging"
           account_id: ${{ secrets.HUBSPOT_STAGING_ACCOUNT_ID }}

--- a/project-validate/action.yml
+++ b/project-validate/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Install HubSpot CLI
-      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.0
+      uses: HubSpot/hubspot-project-actions/install-hubspot-cli@v1.1.2
       with:
         cli_version: ${{ inputs.cli_version }}
     - name: Validate HubSpot project


### PR DESCRIPTION
## Description and Context

- update all executable `actions/checkout` references from v4 to v7 so workflows use the Node 24 runtime
- update copyable examples and composite-action dependencies from HubSpot Project Actions v1.1.0 to the current v1.1.2 release
- keep historical release notes and illustrative version placeholders unchanged

Fixes #55.

## Testing

- parsed all 12 YAML files and 15 fenced YAML examples
- ran `actionlint` against the workflows
- checked the existing shell snippets with `bash -n`
- verified that no executable checkout@v4 or HubSpot Project Actions v1.1.0 references remain

## Screenshots

Not applicable.

## TODO

The developer.hubspot.com example linked from the issue lives outside this repository and can be updated separately.

## AI assistance disclosure

OpenAI Codex was used to analyze, implement, and test this change. The diff and checks listed above were verified in the contribution workspace.

